### PR TITLE
Remove complex configuring of app_path, use relative links instead

### DIFF
--- a/src/handler/content.rs
+++ b/src/handler/content.rs
@@ -310,7 +310,7 @@ pub fn add_comment_by_aid<'a>(conn_pg: &Connection, conn_dsl: &PgConnection, aid
 pub fn get_uids(conn_pg: &Connection, username: &str) -> Option<i32> {
 
     let mut to_uid: Option<i32> = Some(0);
-    for row in &conn_pg.query("SELECT id FROM user WHERE username = $1",&[&username]).unwrap() {
+    for row in &conn_pg.query("SELECT id FROM users WHERE username = $1",&[&username]).unwrap() {
         let uid = ToUid {
             id: row.get(0),
         };

--- a/view/article.tera
+++ b/view/article.tera
@@ -74,8 +74,10 @@
                     </div>
                     <div id="reply">
                         {% if username %}
-                            <div id="write"> Write comment in makedwon! </div>
-                            <textarea class="ans_con" ></textarea>
+                            <div id="write"> Write comment in markdwon! </div>
+                            <textarea class="ans_con" placeholder="if you want @somebody for send a message in your comment, the rule is: 
+                            1: the @ symbol can't be first position at line.(like: @somebodyxxxxx)
+                            2: one position before the @ symbol can't be space(like: xxxxx @somebodyxxxxx)."></textarea>
                             <button type="submit" id="submit" data-aid="{{ article.id }}"><span class="tip"> Comment </span></button>
                             <script type="text/javascript" src="http://mat1.gtimg.com/libs/jquery/1.12.0/jquery.min.js"></script>
                             <script type="text/javascript" >


### PR DESCRIPTION
- Remove complex configuring of app_path, use relative links instead
- Fix typo in `user` -> `users`
- Fix typo in templates